### PR TITLE
count SCORE_PER_ROW

### DIFF
--- a/tetris.c
+++ b/tetris.c
@@ -1100,6 +1100,7 @@ void check_remove_completed_rows( void ) {
     if (is_complete_row(r)) {
       removed++;
       remove_row( r );
+      score += SCORE_PER_ROW;
       if(VT52_mode == 0)
         if(VT100_scroll)
           vt100_scroll_region_down(r-ROW0);


### PR DESCRIPTION
While porting tetris to the icestation-32 I noticed this constant wasn't even being used. I wasn't sure if this is intentional or not, but in any case, this adds scoring per filled row.